### PR TITLE
Use polygon FWEB3 tokens

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import useEagerConnect from "../hooks/useEagerConnect";
 import useTokenBalance from "../hooks/useTokenBalance";
 import { parseBalanceToNum } from "../util";
 
-const FWEB3_TOKEN_ADDRESS = "0x95cd50f9d591630db85d95c932bbc704dc0ae92a";
+const FWEB3_TOKEN_ADDRESS = "0x4a14ac36667b574b08443a15093e417db909d7a3";
 
 export default function Home() {
   const { account, library, active } = useWeb3React();


### PR DESCRIPTION
This switches to the polygon address for the tokens. 

It would take a tiny bit more work to have the site support both Ethereum Mainnet
and polygon at the same time.

I can start investigating that, but in the meantime, I think it makes sense to support Polygon as the default network since the rest of the dot activity will be done on Polygon, right?