### PR TITLE
Add message to switch to Polygon

### DIFF
--- a/components/Account.tsx
+++ b/components/Account.tsx
@@ -70,7 +70,7 @@ const Account = ({ triedToEagerConnect }: AccountProps) => {
 
   return (
     <div>
-      Logged in as{" "}
+      Logged in as {" "}
       <a
         {...{
           href: formatEtherscanLink("Account", [chainId, account]),

--- a/components/Account.tsx
+++ b/components/Account.tsx
@@ -70,7 +70,7 @@ const Account = ({ triedToEagerConnect }: AccountProps) => {
 
   return (
     <div>
-      Logged in as {' '}
+      Logged in as{" "}
       <a
         {...{
           href: formatEtherscanLink("Account", [chainId, account]),
@@ -80,6 +80,7 @@ const Account = ({ triedToEagerConnect }: AccountProps) => {
       >
         {ENSName || `${shortenHex(account, 4)}`}
       </a>
+      {chainId !== 137 ? ` - Please switch to the Polygon Network` : null}
     </div>
   );
 };


### PR DESCRIPTION
Adds a simple message to switch to the Polygon network. 

![image](https://user-images.githubusercontent.com/1197406/154148668-035c8f59-664f-4cfc-82a2-a237682722b0.png)


Resolves #16 
