### PR TITLE
Fix first dot when using query address

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -81,7 +81,7 @@ export default function Home() {
   const { data: polygonData, error } = useSwr(`/api/polygon?wallet_address=${query.wallet ? query.wallet : account}`, fetcher);
 
   let gameTileCompletionStates = [
-    isConnected ? 1 : 0,
+    (isConnected || query.wallet) ? 1 : 0,
     parseBalanceToNum((polygonData && polygonData["tokenBalance"]) ?? 0) >= 100 ? 1 : 0,
     polygonData && polygonData["hasUsedFaucet"] ? 1 : 0,
     polygonData && polygonData["hasSentTokens"] ? 1 : 0,


### PR DESCRIPTION
When using the wallet query address, assume the first dot is complete. 

Possible enhancement: only fill in the first dot if any of the other dots are completed.

Fixes #62 