### PR TITLE
Fix the token balance when using query wallet

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -127,8 +127,11 @@ export default function Home() {
           <p style={{color: "#fff"}}>{query.wallet}</p>
         )}
 
-        {isConnected ? (
-          <TokenBalance balance={polygonData && polygonData["tokenBalance"]} symbol="FWEB3" />
+        {isConnected || query.wallet ? (
+          <TokenBalance
+            balance={polygonData && polygonData["tokenBalance"]}
+            symbol="FWEB3"
+          />
         ) : (
           <div>0 FWEB3</div>
         )}


### PR DESCRIPTION
When using the query param, the token balance in the top right was always `0 FWEB3`