### PR TITLE
fix: local dev crashes when API max rate limit reached

### DIFF
--- a/pages/api/polygon.ts
+++ b/pages/api/polygon.ts
@@ -34,6 +34,13 @@ export default async function handler(req, res) {
     });
   }
 
+  if (balanceJson.status === "0") {
+    return res.status(500).json({
+      message: balanceJson.message,
+      result: balanceJson.result,
+    });
+  }
+
   tokenBalance = balanceJson.result;
 
   const response = await fetch(

--- a/util.ts
+++ b/util.ts
@@ -5,24 +5,12 @@ export const parseBalance = (
   value: BigNumberish,
   decimals = 18,
   decimalsToDisplay = 0
-) => {
-  if (typeof value !== "number") {
-    return null;
-  }
-  return commify(
-    parseFloat(formatUnits(value, decimals)).toFixed(decimalsToDisplay)
-  );
-};
+) =>
+  commify(parseFloat(formatUnits(value, decimals)).toFixed(decimalsToDisplay));
 
 export const parseBalanceToNum = (
   value: BigNumberish,
   decimals = 18,
   decimalsToDisplay = 0
-) => {
-  if (typeof value !== "number") {
-    return null;
-  }
-  return parseInt(
-    parseFloat(formatUnits(value, decimals)).toFixed(decimalsToDisplay)
-  );
-};
+) =>
+  parseInt(parseFloat(formatUnits(value, decimals)).toFixed(decimalsToDisplay));

--- a/util.ts
+++ b/util.ts
@@ -5,10 +5,24 @@ export const parseBalance = (
   value: BigNumberish,
   decimals = 18,
   decimalsToDisplay = 0
-) => commify(parseFloat(formatUnits(value, decimals)).toFixed(decimalsToDisplay));
+) => {
+  if (typeof value !== "number") {
+    return null;
+  }
+  return commify(
+    parseFloat(formatUnits(value, decimals)).toFixed(decimalsToDisplay)
+  );
+};
 
 export const parseBalanceToNum = (
   value: BigNumberish,
   decimals = 18,
   decimalsToDisplay = 0
-) => parseInt(parseFloat(formatUnits(value, decimals)).toFixed(decimalsToDisplay));
+) => {
+  if (typeof value !== "number") {
+    return null;
+  }
+  return parseInt(
+    parseFloat(formatUnits(value, decimals)).toFixed(decimalsToDisplay)
+  );
+};


### PR DESCRIPTION
# what
return 500 code and max rate limit message from `api/polygon`

# why

I was unable to develop because the app kept crashing because anytime `polygonData["tokenBalance"]` was something like `"Max rate limit reached, please use API Key for higher rate limit"` instead of a number, it would cause unhandled runtime error in the utils `parseBalance` and `parseBalanceToNum` because `value` type is `string` instead of `BigNumberish`

https://github.com/slavingia/fweb3.xyz/blob/919c66fecd3b8519c3eeb8da972d231996416bfb/util.ts#L4-L14

## before 
![Screen Shot 2022-02-24 at 9 17 31 PM](https://user-images.githubusercontent.com/892749/155661452-33017bae-c0ed-4c84-badf-d46364855e7b.png) 

## after
![Screen Shot 2022-02-24 at 10 22 10 PM](https://user-images.githubusercontent.com/892749/155665280-caa7b8a3-2653-46f8-bb39-69ad011b89c1.png)

considered different approaches to handling the "max rate limit reached" response getting stored into the api/polygon tokenBalance response value but this seemed to strike the best balance between minimal degrading of UX without obfuscating the underlying issue