### PR TITLE
Add debugging tools

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "url": "http://localhost:3000"
+    },
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev",
+      "console": "integratedTerminal",
+      "serverReadyAction": {
+        "pattern": "started server on .+, url: (https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ To run the tests using [Cypress](https://cypress.io):
 1. Install dev dependencies: `npm install`
 2. Run local server: `npm run dev`
 3. Run Cypress tests in a separate terminal: `npm run e2e`
+
+#### Debugging with devtools
+
+Supports using either the VS Code debugger or Chrome DevTools.
+
+See official Next.js docs: https://nextjs.org/docs/advanced-features/debugging

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "browser-debug": "NODE_OPTIONS='--inspect' next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
# What
Add tools to do live debugging, 2 flavors

## If you run `npm run browser-debug`
You can look at source code in chrome inspector and put breakpoints and use debugger devtools for backend and frontend files

<img width="1095" alt="Screen Shot 2022-02-25 at 10 48 46 PM" src="https://user-images.githubusercontent.com/892749/155833599-f1fdc433-e067-4058-80c4-61ba71232447.png">

## If you go to debug in vs code
<img width="1262" alt="Screen Shot 2022-02-25 at 10 52 12 PM" src="https://user-images.githubusercontent.com/892749/155833758-f0c6d869-73e3-46eb-b16e-95be3ef4f0d0.png">

# Why
I get tired of `console.log('lol wat: ', value)`
