### PR TITLE
cleaned up and turn second dot on as long as they used to have tokens

### DIFF
--- a/pages/api/polygon.ts
+++ b/pages/api/polygon.ts
@@ -14,8 +14,7 @@ export default async function handler(req, res) {
       hasVotedInPoll: parseInt(dots[6]),
       hasDeployedContract: parseInt(dots[7]),
       hasWonGame: parseInt(dots[8]),
-      trophyColor: parseInt(dots[9]),
-      trophyID: parseInt(dots[10]),
+      trophyID: parseInt(dots[9]),
     });
   }
 
@@ -196,6 +195,10 @@ export default async function handler(req, res) {
     if (transaction.from === "0x0000000000000000000000000000000000000000") {
       hasMintedNFT = true;
     }
+  }
+
+  if (hasUsedFaucet || hasSentTokens || hasVotedInPoll) {
+    hasEnoughTokens = true;
   }
 
   res.status(200).json({


### PR DESCRIPTION
- ensure second dot lights up even if player sends tokens away after seeking verification
- removed mention of trophyColor (old code)